### PR TITLE
Add push-sentinel: pre-push secret scanning CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [probot-security-alerts](https://github.com/advanced-security/probot-security-alerts) - Sample GitHub App which monitors and enforces rules for code scanning, Dependabot, and secret scanning alerts
 
 ## Tools
+- [push-sentinel](https://github.com/Pmaind/pre-push-secrets) - Zero-dependency Node.js CLI that installs as a pre-push git hook and scans the exact diff being pushed for secrets (AWS keys, GitHub tokens, private keys, OpenAI/Anthropic API keys). Supports `.push-sentinel-ignore` for suppressing false positives.
 - [ghes-secret-scanning-automation-tools](https://github.com/kraiouchkine/ghes-secret-scanning-automation-tools) - enable automatic resolution and reopening of Secret Scanning alerts on GitHub Enterprise Server
 
 ## Secret Remediation


### PR DESCRIPTION
## What is push-sentinel?

[push-sentinel](https://github.com/Pmaind/pre-push-secrets) is a zero-dependency Node.js CLI that installs as a `pre-push` git hook and scans the exact diff being pushed for secrets before they reach GitHub.

## Why it fits here

It's a secret scanning tool focused on the developer's local workflow — catching secrets at push time rather than after they're already in the repository.

## What it detects

- Private Keys (RSA, EC, OPENSSH, DSA, PKCS#8)
- AWS Access Key / Secret Key (entropy-based)
- GitHub Tokens (`ghp_`, `github_pat_`)
- Anthropic / OpenAI API Keys
- Generic API Keys (variable name + Shannon entropy)
- `.env` file commits

## Install

```sh
npx --yes --prefer-online push-sentinel@latest install
```

- npm: https://www.npmjs.com/package/push-sentinel
- GitHub: https://github.com/Pmaind/pre-push-secrets
- License: MIT