### PR TITLE
Add Vooda to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 ## Tools
 - [nicolaswill/ghes-secret-scanning-automation-tools](https://github.com/nicolaswill/ghes-secret-scanning-automation-tools) - enable automatic resolution and reopening of Secret Scanning alerts on GitHub Enterprise Server
 - [cisco-open/gitguardian-to-ghas-importer](https://github.com/cisco-open/gitguardian-to-ghas-importer) - A Python tool that automatically closes GitHub Advanced Security (GHAS) secret scanning alerts by matching them with previously triaged false positives from GitGuardian exports.
+- [virantisofficial/vooda.ai](https://github.com/virantisofficial/vooda.ai) - Self-hosted secrets detection platform that complements GHAS secret scanning with AI triage, live credential verification, and non-human identity governance.
 
 ## Secret Remediation
 - [advanced-security/GSSAR](https://github.com/advanced-security/GSSAR) - GitHub Secret Scanning Auto Remediator (GSSAR)


### PR DESCRIPTION
Adds [Vooda](https://github.com/virantisofficial/vooda.ai) to the Tools section — a self-hosted secrets detection platform that complements GitHub secret scanning:

- 900+ rules across 53 detector modules with an AI triage layer that classifies findings as true/false positives with confidence scores
- Live credential verification against provider APIs, switchable for air-gapped deployments
- Bring-your-own-model (Ollama, vLLM, LM Studio, any OpenAI-compatible endpoint)
- Scans non-code sources (Slack, Jira, Confluence, Docker images, CI logs) alongside git history
- Source-available under FSL-1.1-ALv2; every release converts to Apache 2.0 two years after publication