### PR TITLE
Add agent-audit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 ## Tools
 - [nicolaswill/ghes-secret-scanning-automation-tools](https://github.com/nicolaswill/ghes-secret-scanning-automation-tools) - enable automatic resolution and reopening of Secret Scanning alerts on GitHub Enterprise Server
 - [cisco-open/gitguardian-to-ghas-importer](https://github.com/cisco-open/gitguardian-to-ghas-importer) - A Python tool that automatically closes GitHub Advanced Security (GHAS) secret scanning alerts by matching them with previously triaged false positives from GitGuardian exports.
+- [CrypLed/agent-audit](https://github.com/CrypLed/agent-audit) - Scans AI coding agent (Claude Code, Codex CLI) session transcripts for secrets that leaked into the conversation via tool output, plus risky shell commands the agent executed. Zero dependencies, fully local.
 
 ## Secret Remediation
 - [advanced-security/GSSAR](https://github.com/advanced-security/GSSAR) - GitHub Secret Scanning Auto Remediator (GSSAR)


### PR DESCRIPTION
Adds [agent-audit](https://github.com/CrypLed/agent-audit) to the Tools section.

It scans AI coding agent session transcripts (Claude Code and Codex CLI store these locally as JSONL by
design, so sessions can resume) for secrets that leaked into the conversation via tool output — API keys,
database connection strings, etc. — and risky shell commands the agent actually executed. Zero runtime
dependencies, fully local (no network calls, no telemetry).

Relevant here specifically because it's a different surface than typical repo/git-history secret scanning:
it looks at what an AI coding assistant saw and did during a session, which is a newer and largely unaudited
place for secrets to end up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)